### PR TITLE
summary position option added in customization menu

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -47,10 +47,6 @@ function rich_snippet_dashboard() {
 		$woo_setting = "Checked";
 	} 
 	
-  /* under the form id="bsf_position_editor": for some very strange reason,
-  // radio options POSTed have the exact opposite effect. So I just inverted
-  // the values in the radio inputs. It's a dirty trick that works fine.
-  */
 	$snippet_position_option_top = '';
 	$snippet_position_option_bottom = '';
 	if( $args_position == "bottom" ) { 
@@ -659,11 +655,11 @@ function rich_snippet_dashboard() {
 											<table class="bsf_metabox">
 												<tr>
 													<th> <label for="snippet_position_option_top"> '.__('Top ', 'rich-snippets').' </label> </th>
-													<td> <input type="radio" name="position_option" id="snippet_position_option_top" value="bottom" '.$snippet_position_option_bottom.' /> </td>
+													<td> <input type="radio" name="position_option" id="snippet_position_option_top" value="top" '.$snippet_position_option_top.' /> </td>
 												</tr>
 												<tr>
 													<th> <label for="snippet_position_option_bottom"> '.__('Bottom', 'rich-snippets').' </label> </th>
-													<td> <input type="radio" name="position_option" id="snippet_position_option_bottom" value="top" '.$snippet_position_option_top.' /> </td>
+													<td> <input type="radio" name="position_option" id="snippet_position_option_bottom" value="bottom" '.$snippet_position_option_bottom.' /> </td>
 												</tr>
 												<tr>
 													<td><input id= "submit_position" type="submit" class="button-primary" name="position_submit" value="'.__("Update ").'"/></td>

--- a/admin/index.php
+++ b/admin/index.php
@@ -23,8 +23,13 @@ function rich_snippet_dashboard() {
 	$plugins_url = plugins_url();
 	if ( !get_option( 'bsf_woocom_init_setting' ) ) {
 		$args_woocom = true;
-	}else {
+	} else {
 		$args_woocom = get_option('bsf_woocom_setting');
+	}
+	if ( !get_option( 'bsf_position_init_setting' ) ) {
+		$args_position = "bottom";
+	} else {
+		$args_position = get_option('bsf_position_setting');
 	}
 	
 	$args_review = get_option('bsf_review');
@@ -41,6 +46,18 @@ function rich_snippet_dashboard() {
 	if( !empty( $args_woocom ) ) { 
 		$woo_setting = "Checked";
 	} 
+	
+  /* under the form id="bsf_position_editor": for some very strange reason,
+  // radio options POSTed have the exact opposite effect. So I just inverted
+  // the values in the radio inputs. It's a dirty trick that works fine.
+  */
+	$snippet_position_option_top = '';
+	$snippet_position_option_bottom = '';
+	if( $args_position == "bottom" ) { 
+		$snippet_position_option_bottom = "Checked";
+	} else {
+		$snippet_position_option_top = "Checked";
+  }
 	
 	if(isset($args_event["event_desc"]) ) { 
 		$event_desc = $args_event["event_desc"]; 
@@ -633,6 +650,29 @@ function rich_snippet_dashboard() {
 										</div>
 									</div>
 								</div>
+								<div class="postbox">
+									<div class="handlediv" title="Click to toggle"><br></div>
+										<h3 class="hndle">'.__("<span>Position of the snippet in the page</span>","rich-snippets").'</h3>
+										<div class="inside">
+											<form id="bsf_position_editor" method="post" action="">
+											'.wp_nonce_field( 'snippet_position_form_action', 'snippet_position_nonce_field' ).'
+											<table class="bsf_metabox">
+												<tr>
+													<th> <label for="snippet_position_option_top"> '.__('Top ', 'rich-snippets').' </label> </th>
+													<td> <input type="radio" name="position_option" id="snippet_position_option_top" value="bottom" '.$snippet_position_option_bottom.' /> </td>
+												</tr>
+												<tr>
+													<th> <label for="snippet_position_option_bottom"> '.__('Bottom', 'rich-snippets').' </label> </th>
+													<td> <input type="radio" name="position_option" id="snippet_position_option_bottom" value="top" '.$snippet_position_option_top.' /> </td>
+												</tr>
+												<tr>
+													<td><input id= "submit_position" type="submit" class="button-primary" name="position_submit" value="'.__("Update ").'"/></td>
+												</tr>
+											</table>
+											</form>
+										</div>
+									</div>
+								</div>
 							</div>
 					</div>
 				</div>
@@ -688,6 +728,27 @@ function rich_snippet_dashboard() {
 }
 // Update options
 
+if(isset($_POST['position_submit']))
+{
+	if ( ! isset( $_POST['snippet_position_nonce_field'] ) || ! wp_verify_nonce( $_POST['snippet_position_nonce_field'], 'snippet_position_form_action' ) 
+		) {
+		   print 'Sorry, your nonce did not verify.';
+		   exit;
+		} 
+	else {
+		$args = null;
+		if(isset($_POST["position_option"])) 
+		{
+			$args = $_POST["position_option"];
+		}	
+		else {
+			$args = "bottom";
+		}	
+		update_option( 'bsf_position_init_setting', 'done' );
+		$status = update_option('bsf_position_setting',$args);
+		displayStatus($status);
+	}
+}
 if(isset($_POST['setting_submit']))
 {
 	if ( ! isset( $_POST['snippet_woocommerce_nonce_field'] ) || ! wp_verify_nonce( $_POST['snippet_woocommerce_nonce_field'], 'snippet_woocommerce_form_action' ) 
@@ -955,7 +1016,7 @@ function add_footer_script()
         {
             var data = jQuery("#bsf_css_editor").serialize();
             var form_data = "action=bsf_submit_color&" + data;
-          //alert(form_data);
+            alert(form_data);
             jQuery.post(ajaxurl, form_data,
                 function (response) {
                     alert(response);

--- a/functions.php
+++ b/functions.php
@@ -58,9 +58,12 @@ function display_rich_snippet($content) {
 	$args_color = get_option('bsf_custom');
 	$id = $post->ID;
 	$type = get_post_meta($id, '_bsf_post_type', true);
+  
   $args_position = get_option('bsf_position_setting');
-  $content_top = $content_bottom = '';
-  if ($args_position == 'top') {
+  $content_top = '';
+  $content_bottom = '';
+  // for some strange reason, bsf_position_setting option value is inverted 
+  if ($args_position == 'bottom') {
     $content_top = $content;
   } else $content_bottom = $content;
   

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,7 @@
 <?php
+// Place Snippet at the top https://wordpress.org/support/topic/place-snippet-at-the-top/
+// github https://github.com/UttamSharma007/all-in-one-schemaorg-rich-snippets/tree/summary_pos
+
 /**
  * Template Name: Plugin Functions
  *
@@ -55,7 +58,12 @@ function display_rich_snippet($content) {
 	$args_color = get_option('bsf_custom');
 	$id = $post->ID;
 	$type = get_post_meta($id, '_bsf_post_type', true);
-
+  $args_position = get_option('bsf_position_setting');
+  $content_top = $content_bottom = '';
+  if ($args_position == 'top') {
+    $content_top = $content;
+  } else $content_bottom = $content;
+  
 	if($type == '1')
 	{
 		global $post;
@@ -118,7 +126,7 @@ function display_rich_snippet($content) {
 				echo $review;
 			}		
 		}
-		else { return ( is_single() || is_page() ) ? $content.$review : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$review.$content_bottom : $content; }
 	} 
 	else if($type == '2')
 	{
@@ -232,7 +240,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$event : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$event.$content_bottom : $content; }
 	}
 	else if($type == '4')
 	{
@@ -290,7 +298,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$organization : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$organization.$content_bottom : $content; }
 	}
 	else if($type == '5')
 	{
@@ -396,7 +404,7 @@ function display_rich_snippet($content) {
 				echo $people;
 			}	
 		}
-		else { return ( is_single() || is_page() ) ? $content.$people : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$people.$content_bottom : $content; }
 	}
 	else if($type == '6')
 	{
@@ -506,7 +514,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$product : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$product.$content_bottom : $content; }
 	}
 	else if($type == '7')
 	{
@@ -613,7 +621,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$recipe : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$recipe.$content_bottom : $content; }
 	}
 	else if($type == '8')
 	{
@@ -725,7 +733,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$software : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$software.$content_bottom : $content; }
 	}
 	else if($type == '9')
 	{
@@ -798,7 +806,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$video : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$video.$content_bottom : $content; }
 	}
 	else if($type == '10')
 	{
@@ -913,7 +921,7 @@ function display_rich_snippet($content) {
 			}
 		}
 	
-		else { return ( is_single() || is_page() ) ? $content.$article : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$article.$content_bottom : $content; }
 	}else if($type == '11')
 	{
 		global $post;
@@ -1050,7 +1058,7 @@ function display_rich_snippet($content) {
 			}
 			
 		}
-		else { return ( is_single() || is_page() ) ? $content.$service : $content; }
+		else { return ( is_single() || is_page() ) ? $content_top.$service.$content_bottom : $content; }
 	}	
 	 else {
 		return $content;

--- a/index.php
+++ b/index.php
@@ -156,6 +156,7 @@ if ( !class_exists( "RichSnippets" ) )
 		function register_bsf_settings() {
 			require_once(plugin_dir_path( __FILE__ ).'settings.php');
 			add_woo_commerce_option();
+			add_position_option();
 			add_review_option();
 			add_event_option();
 			add_person_option();
@@ -258,7 +259,27 @@ if ( !class_exists( "RichSnippets" ) )
 					'snippet_title_color'  =>	$title_color,
 					'snippet_box_color'	=>	$box_color,
 				);
-				echo update_option('bsf_custom',$color_opt) ? _e( 'Settings saved !', 'rich-snippets') : _e( 'Error occured. Satings were not saved !', 'rich-snippets' );
+				echo update_option('bsf_custom',$color_opt) ? _e( 'Settings saved !', 'rich-snippets') : _e( 'Error occured. Settings were not saved !', 'rich-snippets' );
+
+				die();
+				}
+			}
+		}
+		function submit_position()
+		{
+			if ( ! current_user_can( 'manage_options'  ) ) {
+				// return if current user is not allowed to manage options.
+				return;
+			}
+			else {
+				if ( ! isset( $_POST['snippet_position_nonce_field'] ) || ! wp_verify_nonce( $_POST['snippet_position_nonce_field'], 'snippet_position_form_action' ) 
+				) {
+				   print 'Sorry, your nonce did not verify.';
+				   exit;
+				} 
+				else {
+				$position_option = esc_attr( $_POST['position_option'] );
+				echo update_option('bsf_custom',$position_option) ? _e( 'Settings saved !', 'rich-snippets') : _e( 'Error occured. Settings were not saved !', 'rich-snippets' );
 
 				die();
 				}

--- a/settings.php
+++ b/settings.php
@@ -149,7 +149,7 @@ function add_color_option()
 	add_option('bsf_custom',$color_opt);
 }
 
-// Function for customization
+// Function for woo_commerce customization
 function add_woo_commerce_option()
 {
 	if ( !get_option( 'bsf_woocom_init_setting' ) ) {
@@ -162,6 +162,19 @@ function add_woo_commerce_option()
 		
 		add_option('bsf_woocom_setting', $woo_opt);
 		add_option('bsf_woocom_init_setting', 'done');
+	}
+}
+
+// Function for position customization
+function add_position_option()
+{
+	if ( !get_option( 'bsf_position_init_setting' ) ) {
+		// default
+		$position_opt = "bottom";
+  } else $position_opt = get_option( 'bsf_position_init_setting' );
+		
+		add_option('bsf_position_setting', $position_opt);
+		add_option('bsf_position_init_setting', 'done');
 	}
 }
 


### PR DESCRIPTION
I hope you'll be able to merge this with your _summary_pos_ branch, because I couldn't commit on that branch in the cloned repo, it says "authentication required". I'm no gitnerd yet and I don't understand why I can't.
Modified files to reflect new options in the customization tab:
index.php
functions.php
settings.php
admin/index.php

it was not easy... I take that your plugin took a long time to develop and is an incremental pile of pulls and commits from different people... I think it's the only one time I will pull something for you lol

note: under the form id="bsf_position_editor": for some very strange reason, radio options POSTed will have the exact opposite effect. So I just inverted the values in the radio inputs. It's a dirty trick but it works. 